### PR TITLE
Sync upstream PR 4193: add service year filters for reports

### DIFF
--- a/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/index.types.ts
@@ -2,4 +2,6 @@ export type AuxiliaryPioneersProps = {
   wholeYear: boolean;
   year: string;
   month: string;
+  publisherGroup: string;
+  period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/fulltime_servants/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/fulltime_servants/index.types.ts
@@ -2,4 +2,6 @@ export type FulltimeServantsProps = {
   wholeYear: boolean;
   year: string;
   month: string;
+  publisherGroup: string;
+  period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/fulltime_servants/useFulltimeServants.tsx
+++ b/src/features/reports/publisher_records/years_stats/fulltime_servants/useFulltimeServants.tsx
@@ -8,9 +8,9 @@ import useReportYearly from '@features/reports/hooks/useReportYearly';
 import useReportMonthly from '@features/reports/hooks/useReportMonthly';
 
 const useFulltimeServants = ({
-  month,
-  wholeYear,
   year,
+  publisherGroup,
+  period,
 }: FulltimeServantsProps) => {
   const { t } = useAppTranslation();
 
@@ -18,33 +18,52 @@ const useFulltimeServants = ({
   const { personHasReportYear, getFTSReportsYear } = useReportYearly();
   const { personHasReport, getFTSReportsMonth } = useReportMonthly();
 
+  // Helper to filter persons by group
+  const filterByGroup = (persons: PersonType[]) => {
+    if (publisherGroup === 'all') return persons;
+    return persons.filter((p) =>
+      p.person_data.groups?.includes(publisherGroup)
+    );
+  };
+
+  // Determine period
+  const isWholeYear = period === 'serviceYear';
+  const selectedMonth = isWholeYear ? '' : period;
+
   const field_reports = useMemo(() => {
     let result: CongFieldServiceReportType[];
-
-    if (wholeYear) {
+    if (isWholeYear) {
       result = getFTSReportsYear(year);
+    } else {
+      result = getFTSReportsMonth(selectedMonth);
     }
-
-    if (!wholeYear) {
-      result = getFTSReportsMonth(month);
-    }
-
-    return result;
-  }, [wholeYear, year, month, getFTSReportsYear, getFTSReportsMonth]);
+    if (publisherGroup === 'all') return result;
+    return result.filter((r) => r.person_data.groups?.includes(publisherGroup));
+  }, [
+    isWholeYear,
+    year,
+    selectedMonth,
+    getFTSReportsYear,
+    getFTSReportsMonth,
+    publisherGroup,
+  ]);
 
   const persons = useMemo(() => {
     let persons: PersonType[];
-
-    if (wholeYear) {
+    if (isWholeYear) {
       persons = getFTSYears(year);
+    } else {
+      persons = getFTSMonths(selectedMonth);
     }
-
-    if (!wholeYear) {
-      persons = getFTSMonths(month);
-    }
-
-    return persons;
-  }, [wholeYear, year, month, getFTSYears, getFTSMonths]);
+    return filterByGroup(persons);
+  }, [
+    isWholeYear,
+    year,
+    selectedMonth,
+    getFTSYears,
+    getFTSMonths,
+    publisherGroup,
+  ]);
 
   const total = useMemo(() => {
     return persons.length;
@@ -57,12 +76,12 @@ const useFulltimeServants = ({
     for (const person of persons) {
       let hasReport = false;
 
-      if (wholeYear) {
+      if (isWholeYear) {
         hasReport = personHasReportYear(person, year);
       }
 
-      if (!wholeYear) {
-        hasReport = personHasReport(person, month);
+      if (!isWholeYear) {
+        hasReport = personHasReport(person, selectedMonth);
       }
 
       if (hasReport) shared++;
@@ -71,7 +90,14 @@ const useFulltimeServants = ({
     }
 
     return { shared, none };
-  }, [persons, year, wholeYear, month, personHasReportYear, personHasReport]);
+  }, [
+    persons,
+    isWholeYear,
+    year,
+    selectedMonth,
+    personHasReportYear,
+    personHasReport,
+  ]);
 
   const hours = useMemo(() => {
     const sum = field_reports.reduce(

--- a/src/features/reports/publisher_records/years_stats/publishers/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/publishers/index.types.ts
@@ -2,4 +2,6 @@ export type PublishersProps = {
   wholeYear: boolean;
   year: string;
   month: string;
+  publisherGroup: string;
+  period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/total_statistics/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/total_statistics/index.types.ts
@@ -1,3 +1,5 @@
 export type TotalStatisticsProps = {
   year: string;
+  publisherGroup: string;
+  period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/total_statistics/useTotalStatistics.tsx
+++ b/src/features/reports/publisher_records/years_stats/total_statistics/useTotalStatistics.tsx
@@ -8,7 +8,7 @@ import usePersons from '@features/persons/hooks/usePersons';
 import usePerson from '@features/persons/hooks/usePerson';
 import useReportYearly from '@features/reports/hooks/useReportYearly';
 
-const useTotalStatistics = ({ year }: TotalStatisticsProps) => {
+const useTotalStatistics = ({ year, publisherGroup }: TotalStatisticsProps) => {
   const { t } = useAppTranslation();
 
   const { getPublisherAllYears, getPublishersActive, getAPMonths } =
@@ -30,11 +30,18 @@ const useTotalStatistics = ({ year }: TotalStatisticsProps) => {
     return buildServiceYearsList();
   }, []);
 
+  // Helper to filter persons by group
+  const filterByGroup = (persons) => {
+    if (publisherGroup === 'all') return persons;
+    return persons.filter((p) =>
+      p.person_data.groups?.includes(publisherGroup)
+    );
+  };
+
   const publishers_list = useMemo(() => {
     const result = getPublisherAllYears(year);
-
-    return result;
-  }, [year, getPublisherAllYears]);
+    return filterByGroup(result);
+  }, [year, getPublisherAllYears, publisherGroup]);
 
   const publishers_total = useMemo(() => {
     const count = publishers_list.length;

--- a/src/features/reports/publisher_records/years_stats/year_details/index.tsx
+++ b/src/features/reports/publisher_records/years_stats/year_details/index.tsx
@@ -1,22 +1,57 @@
 import { Box, Stack } from '@mui/material';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
-import { YearDetailsProps } from './index.types';
+import {
+  YearDetailsProps,
+  PeriodOption,
+  PublisherGroupOption,
+} from './index.types';
 import useYearDetails from './useYearDetails';
 import AuxiliaryPioneers from '../auxiliary_pioneers';
 import FulltimeServants from '../fulltime_servants';
-import MonthSelector from '@features/reports/service_year_month_selector/month_selector';
 import Publishers from '../publishers';
-import SwitchWithLabel from '@components/switch_with_label';
 import TotalStatistics from '../total_statistics';
-import Tooltip from '@components/tooltip';
+import useFieldServiceGroups from '@features/congregation/field_service_groups/useFieldServiceGroups';
+import Select from '@components/select';
+import MenuItem from '@components/menuitem';
+import Typography from '@components/typography';
+import { buildServiceYearsList } from '@utils/date';
 
 const YearDetails = (props: YearDetailsProps) => {
   const { t } = useAppTranslation();
-
   const { laptopUp } = useBreakpoints();
+  const {
+    year,
+    publisherGroup,
+    period,
+    handlePublisherGroupChange,
+    handlePeriodChange,
+  } = useYearDetails(props);
+  const { groups_list } = useFieldServiceGroups();
 
-  const { year, month, handleMonthChange, wholeYear, handleToggleWholeYear } =
-    useYearDetails(props);
+  // Publisher group options
+  const publisherGroupOptions: PublisherGroupOption[] = [
+    { label: t('tr_allPublishers'), value: 'all' },
+    ...groups_list.map((g) => ({
+      label:
+        g.group.group_data.name && g.group.group_data.name.length > 0
+          ? g.group.group_data.name
+          : t('tr_groupNumber', {
+              groupNumber: g.group.group_data.sort_index + 1,
+            }),
+      value: g.group.group_id,
+    })),
+  ];
+
+  // Build period options for the selected year
+  const serviceYears = buildServiceYearsList();
+  const yearObj = serviceYears.find((y) => y.year === year);
+  const months = yearObj ? yearObj.months : [];
+
+  // Period options: Service year + months
+  const periodOptions: PeriodOption[] = [
+    { label: t('tr_serviceYear'), value: 'serviceYear' },
+    ...months.map((m) => ({ label: m.label, value: m.value })),
+  ];
 
   return (
     <Stack spacing="16px" marginBottom="-24px">
@@ -26,39 +61,90 @@ const YearDetails = (props: YearDetailsProps) => {
         alignItems={laptopUp ? 'center' : 'stretch'}
         justifyContent="space-between"
       >
-        <Tooltip
-          title={t('tr_wholeYearIsSelected')}
-          delaySpeed={'fast'}
-          show={wholeYear}
-          followCursor
-          sx={{ flex: 1 }}
-        >
-          <MonthSelector
-            year={year}
-            value={month}
-            onChange={handleMonthChange}
-            readOnly={wholeYear}
-            sx={{
-              flex: 1,
+        <Box sx={{ flex: 1 }}>
+          <Select
+            label={t('tr_publishers')}
+            value={publisherGroup}
+            onChange={(e) =>
+              handlePublisherGroupChange(e.target.value as string)
+            }
+            sx={{ minWidth: 180, marginRight: 2 }}
+          >
+            {publisherGroupOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Select
+            label={t('tr_period')}
+            value={period}
+            onChange={(e) => handlePeriodChange(e.target.value as string)}
+            sx={{ minWidth: 180 }}
+            renderValue={(selected) => {
+              const found = periodOptions.find((o) => o.value === selected);
+              return found ? found.label : '';
             }}
-          />
-        </Tooltip>
-        <Box>
-          <SwitchWithLabel
-            label={t('tr_wholeYearSetting')}
-            checked={wholeYear}
-            onChange={handleToggleWholeYear}
-          />
+          >
+            {/* Section: Whole year */}
+            <Typography
+              sx={{
+                px: 2,
+                py: 1,
+                color: 'var(--accent-main)',
+                fontWeight: 600,
+              }}
+            >
+              {t('tr_wholeYear')}
+            </Typography>
+            <MenuItem value="serviceYear">{t('tr_serviceYear')}</MenuItem>
+            {/* Section: Months */}
+            <Typography
+              sx={{
+                px: 2,
+                py: 1,
+                color: 'var(--accent-main)',
+                fontWeight: 600,
+              }}
+            >
+              {t('tr_months')}
+            </Typography>
+            {months.map((m) => (
+              <MenuItem key={m.value} value={m.value}>
+                {m.label}
+              </MenuItem>
+            ))}
+          </Select>
         </Box>
       </Stack>
-
-      <FulltimeServants month={month} year={year} wholeYear={wholeYear} />
-
-      <AuxiliaryPioneers month={month} year={year} wholeYear={wholeYear} />
-
-      <Publishers month={month} year={year} wholeYear={wholeYear} />
-
-      <TotalStatistics year={year} />
+      <FulltimeServants
+        year={year}
+        month={''}
+        wholeYear={period === 'serviceYear'}
+        publisherGroup={publisherGroup}
+        period={period}
+      />
+      <AuxiliaryPioneers
+        year={year}
+        month={''}
+        wholeYear={period === 'serviceYear'}
+        publisherGroup={publisherGroup}
+        period={period}
+      />
+      <Publishers
+        year={year}
+        month={''}
+        wholeYear={period === 'serviceYear'}
+        publisherGroup={publisherGroup}
+        period={period}
+      />
+      <TotalStatistics
+        year={year}
+        publisherGroup={publisherGroup}
+        period={period}
+      />
     </Stack>
   );
 };

--- a/src/features/reports/publisher_records/years_stats/year_details/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/year_details/index.types.ts
@@ -1,5 +1,17 @@
 export type YearDetailsProps = {
   year: string;
+  publisherGroup: string;
+  period: string;
+};
+
+export type PeriodOption = {
+  label: string;
+  value: string;
+};
+
+export type PublisherGroupOption = {
+  label: string;
+  value: string;
 };
 
 export type PublisherReportOption = {

--- a/src/features/reports/publisher_records/years_stats/year_details/useYearDetails.tsx
+++ b/src/features/reports/publisher_records/years_stats/year_details/useYearDetails.tsx
@@ -4,14 +4,17 @@ import { YearDetailsProps } from './index.types';
 const useYearDetails = ({ year }: YearDetailsProps) => {
   const [wholeYear, setWholeYear] = useState(true);
   const [month, setMonth] = useState('');
+  const [publisherGroup, setPublisherGroup] = useState('all');
+  const [period, setPeriod] = useState('serviceYear');
 
   const handleMonthChange = (value: string) => setMonth(value);
-
   const handleToggleWholeYear = (value: boolean) => setWholeYear(value);
+  const handlePublisherGroupChange = (value: string) =>
+    setPublisherGroup(value);
+  const handlePeriodChange = (value: string) => setPeriod(value);
 
   useEffect(() => {
     if (wholeYear) setMonth('');
-
     if (!wholeYear) {
       setMonth(`${+year - 1}/09`);
     }
@@ -23,6 +26,10 @@ const useYearDetails = ({ year }: YearDetailsProps) => {
     handleMonthChange,
     handleToggleWholeYear,
     year,
+    publisherGroup,
+    period,
+    handlePublisherGroupChange,
+    handlePeriodChange,
   };
 };
 

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -499,5 +499,10 @@
   "tr_cantAddANewGroup": "Can't add a new group",
   "tr_maximumAmountOfGroupsIs10": "Maximum amount of field service groups is 10",
   "tr_personAwayNotice": "This person is away: {{ date }}",
-  "tr_weekendTemplateShowSongs": "Display songs on weekend meeting schedules"
+  "tr_weekendTemplateShowSongs": "Display songs on weekend meeting schedules",
+  "tr_allPublishers": "All publishers",
+  "tr_serviceYear": "Service year",
+  "tr_period": "Period",
+  "tr_wholeYear": "Whole year",
+  "tr_months": "Months"
 }


### PR DESCRIPTION
## Summary
- cherry-pick draft PR 4193 to add service-year and period filters for publisher record reports
- add translation keys for period selection

## Testing
- `npx cypress run --browser electron` *(fails: 1 failing test in spec.cy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b78615198832f962cabdd65af4de0