### PR TITLE
feat: add publisher and period filters for stats

### DIFF
--- a/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/index.types.ts
@@ -1,7 +1,5 @@
 export type AuxiliaryPioneersProps = {
-  wholeYear: boolean;
   year: string;
-  month: string;
   publisherGroup: string;
   period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/useAuxiliaryPioneers.tsx
+++ b/src/features/reports/publisher_records/years_stats/auxiliary_pioneers/useAuxiliaryPioneers.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useAppTranslation } from '@hooks/index';
 import { PersonType } from '@definition/person';
 import { CongFieldServiceReportType } from '@definition/cong_field_service_reports';
@@ -19,12 +19,15 @@ const useAuxiliaryPioneers = ({
   const { personHasReport, getAPReportsMonth } = useReportMonthly();
 
   // Helper to filter persons by group
-  const filterByGroup = (persons: PersonType[]) => {
-    if (publisherGroup === 'all') return persons;
-    return persons.filter((p) =>
-      p.person_data.groups?.includes(publisherGroup)
-    );
-  };
+  const filterByGroup = useCallback(
+    (persons: PersonType[]) => {
+      if (publisherGroup === 'all') return persons;
+      return persons.filter((p) =>
+        p.person_data.groups?.includes(publisherGroup)
+      );
+    },
+    [publisherGroup]
+  );
 
   // Determine period
   const isWholeYear = period === 'serviceYear';
@@ -62,7 +65,7 @@ const useAuxiliaryPioneers = ({
     selectedMonth,
     getAPYears,
     getAPMonths,
-    publisherGroup,
+    filterByGroup,
   ]);
 
   const total = useMemo(() => {

--- a/src/features/reports/publisher_records/years_stats/fulltime_servants/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/fulltime_servants/index.types.ts
@@ -1,7 +1,5 @@
 export type FulltimeServantsProps = {
-  wholeYear: boolean;
   year: string;
-  month: string;
   publisherGroup: string;
   period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/fulltime_servants/useFulltimeServants.tsx
+++ b/src/features/reports/publisher_records/years_stats/fulltime_servants/useFulltimeServants.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useAppTranslation } from '@hooks/index';
 import { PersonType } from '@definition/person';
 import { CongFieldServiceReportType } from '@definition/cong_field_service_reports';
@@ -19,12 +19,15 @@ const useFulltimeServants = ({
   const { personHasReport, getFTSReportsMonth } = useReportMonthly();
 
   // Helper to filter persons by group
-  const filterByGroup = (persons: PersonType[]) => {
-    if (publisherGroup === 'all') return persons;
-    return persons.filter((p) =>
-      p.person_data.groups?.includes(publisherGroup)
-    );
-  };
+  const filterByGroup = useCallback(
+    (persons: PersonType[]) => {
+      if (publisherGroup === 'all') return persons;
+      return persons.filter((p) =>
+        p.person_data.groups?.includes(publisherGroup)
+      );
+    },
+    [publisherGroup]
+  );
 
   // Determine period
   const isWholeYear = period === 'serviceYear';
@@ -62,7 +65,7 @@ const useFulltimeServants = ({
     selectedMonth,
     getFTSYears,
     getFTSMonths,
-    publisherGroup,
+    filterByGroup,
   ]);
 
   const total = useMemo(() => {

--- a/src/features/reports/publisher_records/years_stats/publishers/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/publishers/index.types.ts
@@ -1,7 +1,5 @@
 export type PublishersProps = {
-  wholeYear: boolean;
   year: string;
-  month: string;
   publisherGroup: string;
   period: string;
 };

--- a/src/features/reports/publisher_records/years_stats/publishers/usePublishers.tsx
+++ b/src/features/reports/publisher_records/years_stats/publishers/usePublishers.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useAppTranslation } from '@hooks/index';
 import { PersonType } from '@definition/person';
 import { CongFieldServiceReportType } from '@definition/cong_field_service_reports';
@@ -15,12 +15,15 @@ const usePublishers = ({ year, publisherGroup, period }: PublishersProps) => {
   const { personHasReport, getPublisherReportsMonth } = useReportMonthly();
 
   // Helper to filter persons by group
-  const filterByGroup = (persons: PersonType[]) => {
-    if (publisherGroup === 'all') return persons;
-    return persons.filter((p) =>
-      p.person_data.groups?.includes(publisherGroup)
-    );
-  };
+  const filterByGroup = useCallback(
+    (persons: PersonType[]) => {
+      if (publisherGroup === 'all') return persons;
+      return persons.filter((p) =>
+        p.person_data.groups?.includes(publisherGroup)
+      );
+    },
+    [publisherGroup]
+  );
 
   // Determine period
   const isWholeYear = period === 'serviceYear';
@@ -58,7 +61,7 @@ const usePublishers = ({ year, publisherGroup, period }: PublishersProps) => {
     selectedMonth,
     getPublisherYears,
     getPublisherMonths,
-    publisherGroup,
+    filterByGroup,
   ]);
 
   const total = useMemo(() => {

--- a/src/features/reports/publisher_records/years_stats/total_statistics/useTotalStatistics.tsx
+++ b/src/features/reports/publisher_records/years_stats/total_statistics/useTotalStatistics.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
 import { useAppTranslation } from '@hooks/index';
 import { buildServiceYearsList } from '@utils/date';
@@ -31,17 +31,20 @@ const useTotalStatistics = ({ year, publisherGroup }: TotalStatisticsProps) => {
   }, []);
 
   // Helper to filter persons by group
-  const filterByGroup = (persons) => {
-    if (publisherGroup === 'all') return persons;
-    return persons.filter((p) =>
-      p.person_data.groups?.includes(publisherGroup)
-    );
-  };
+  const filterByGroup = useCallback(
+    (persons) => {
+      if (publisherGroup === 'all') return persons;
+      return persons.filter((p) =>
+        p.person_data.groups?.includes(publisherGroup)
+      );
+    },
+    [publisherGroup]
+  );
 
   const publishers_list = useMemo(() => {
     const result = getPublisherAllYears(year);
     return filterByGroup(result);
-  }, [year, getPublisherAllYears, publisherGroup]);
+  }, [year, getPublisherAllYears, filterByGroup]);
 
   const publishers_total = useMemo(() => {
     const count = publishers_list.length;
@@ -50,10 +53,10 @@ const useTotalStatistics = ({ year, publisherGroup }: TotalStatisticsProps) => {
 
   const publishers_active = useMemo(() => {
     const lastMonth = `${year}/08`;
-    const count = getPublishersActive(lastMonth).length;
+    const count = filterByGroup(getPublishersActive(lastMonth)).length;
 
     return count;
-  }, [year, getPublishersActive]);
+  }, [year, getPublishersActive, filterByGroup]);
 
   const publishers_inactive = useMemo(() => {
     return publishers_total - publishers_active;

--- a/src/features/reports/publisher_records/years_stats/year_details/index.tsx
+++ b/src/features/reports/publisher_records/years_stats/year_details/index.tsx
@@ -1,10 +1,6 @@
 import { Box, Stack } from '@mui/material';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
-import {
-  YearDetailsProps,
-  PeriodOption,
-  PublisherGroupOption,
-} from './index.types';
+import { YearDetailsProps, PeriodOption } from './index.types';
 import useYearDetails from './useYearDetails';
 import AuxiliaryPioneers from '../auxiliary_pioneers';
 import FulltimeServants from '../fulltime_servants';
@@ -13,7 +9,7 @@ import TotalStatistics from '../total_statistics';
 import useFieldServiceGroups from '@features/congregation/field_service_groups/useFieldServiceGroups';
 import Select from '@components/select';
 import MenuItem from '@components/menuitem';
-import Typography from '@components/typography';
+import MenuSubHeader from '@components/menu_sub_header';
 import { buildServiceYearsList } from '@utils/date';
 
 const YearDetails = (props: YearDetailsProps) => {
@@ -27,20 +23,6 @@ const YearDetails = (props: YearDetailsProps) => {
     handlePeriodChange,
   } = useYearDetails(props);
   const { groups_list } = useFieldServiceGroups();
-
-  // Publisher group options
-  const publisherGroupOptions: PublisherGroupOption[] = [
-    { label: t('tr_allPublishers'), value: 'all' },
-    ...groups_list.map((g) => ({
-      label:
-        g.group.group_data.name && g.group.group_data.name.length > 0
-          ? g.group.group_data.name
-          : t('tr_groupNumber', {
-              groupNumber: g.group.group_data.sort_index + 1,
-            }),
-      value: g.group.group_id,
-    })),
-  ];
 
   // Build period options for the selected year
   const serviceYears = buildServiceYearsList();
@@ -70,9 +52,15 @@ const YearDetails = (props: YearDetailsProps) => {
             }
             sx={{ minWidth: 180, marginRight: 2 }}
           >
-            {publisherGroupOptions.map((option) => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
+            <MenuItem value="all">{t('tr_allPublishers')}</MenuItem>
+            <MenuSubHeader>{t('tr_fieldServiceGroups')}</MenuSubHeader>
+            {groups_list.map((g) => (
+              <MenuItem key={g.group.group_id} value={g.group.group_id}>
+                {g.group.group_data.name && g.group.group_data.name.length > 0
+                  ? g.group.group_data.name
+                  : t('tr_groupNumber', {
+                      groupNumber: g.group.group_data.sort_index + 1,
+                    })}
               </MenuItem>
             ))}
           </Select>
@@ -88,29 +76,9 @@ const YearDetails = (props: YearDetailsProps) => {
               return found ? found.label : '';
             }}
           >
-            {/* Section: Whole year */}
-            <Typography
-              sx={{
-                px: 2,
-                py: 1,
-                color: 'var(--accent-main)',
-                fontWeight: 600,
-              }}
-            >
-              {t('tr_wholeYear')}
-            </Typography>
+            <MenuSubHeader>{t('tr_wholeYear')}</MenuSubHeader>
             <MenuItem value="serviceYear">{t('tr_serviceYear')}</MenuItem>
-            {/* Section: Months */}
-            <Typography
-              sx={{
-                px: 2,
-                py: 1,
-                color: 'var(--accent-main)',
-                fontWeight: 600,
-              }}
-            >
-              {t('tr_months')}
-            </Typography>
+            <MenuSubHeader>{t('tr_months')}</MenuSubHeader>
             {months.map((m) => (
               <MenuItem key={m.value} value={m.value}>
                 {m.label}
@@ -121,22 +89,16 @@ const YearDetails = (props: YearDetailsProps) => {
       </Stack>
       <FulltimeServants
         year={year}
-        month={''}
-        wholeYear={period === 'serviceYear'}
         publisherGroup={publisherGroup}
         period={period}
       />
       <AuxiliaryPioneers
         year={year}
-        month={''}
-        wholeYear={period === 'serviceYear'}
         publisherGroup={publisherGroup}
         period={period}
       />
       <Publishers
         year={year}
-        month={''}
-        wholeYear={period === 'serviceYear'}
         publisherGroup={publisherGroup}
         period={period}
       />

--- a/src/features/reports/publisher_records/years_stats/year_details/index.types.ts
+++ b/src/features/reports/publisher_records/years_stats/year_details/index.types.ts
@@ -1,23 +1,8 @@
 export type YearDetailsProps = {
   year: string;
-  publisherGroup: string;
-  period: string;
 };
 
 export type PeriodOption = {
   label: string;
   value: string;
-};
-
-export type PublisherGroupOption = {
-  label: string;
-  value: string;
-};
-
-export type PublisherReportOption = {
-  section: string;
-  reports: {
-    label: string;
-    value: number;
-  }[];
 };

--- a/src/features/reports/publisher_records/years_stats/year_details/useYearDetails.tsx
+++ b/src/features/reports/publisher_records/years_stats/year_details/useYearDetails.tsx
@@ -1,30 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { YearDetailsProps } from './index.types';
 
 const useYearDetails = ({ year }: YearDetailsProps) => {
-  const [wholeYear, setWholeYear] = useState(true);
-  const [month, setMonth] = useState('');
   const [publisherGroup, setPublisherGroup] = useState('all');
   const [period, setPeriod] = useState('serviceYear');
 
-  const handleMonthChange = (value: string) => setMonth(value);
-  const handleToggleWholeYear = (value: boolean) => setWholeYear(value);
-  const handlePublisherGroupChange = (value: string) =>
-    setPublisherGroup(value);
+  const handlePublisherGroupChange = (value: string) => setPublisherGroup(value);
   const handlePeriodChange = (value: string) => setPeriod(value);
 
-  useEffect(() => {
-    if (wholeYear) setMonth('');
-    if (!wholeYear) {
-      setMonth(`${+year - 1}/09`);
-    }
-  }, [wholeYear, year]);
-
   return {
-    wholeYear,
-    month,
-    handleMonthChange,
-    handleToggleWholeYear,
     year,
     publisherGroup,
     period,


### PR DESCRIPTION
## Summary
- refactor publisher records stats to filter by publisher group and period
- memoize group filter helpers to satisfy hook dependencies

## Testing
- `npm run lint`
- `npm test` *(fails: Browser chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b83817b2c832fbf6e1c7da916e7ac