### PR TITLE
fix(ui): fix congregation and group selection size

### DIFF
--- a/src/features/language_group_selector/index.tsx
+++ b/src/features/language_group_selector/index.tsx
@@ -9,7 +9,7 @@ import Typography from '@components/typography';
 const LanguageGroupSelector = () => {
   const { tablet688Up } = useBreakpoints();
 
-  const { display, options, value, renderValue, handleChange } =
+  const { display, options, value, renderValue, handleChange, selectWidth } =
     useGroupLanguageSelector();
 
   if (!display) return <></>;
@@ -23,7 +23,7 @@ const LanguageGroupSelector = () => {
         }
         renderValue={(value: string) => renderValue(value)}
         sx={{
-          width: tablet688Up ? '250px' : '100%',
+          width: tablet688Up ? `${selectWidth}px` : '100%',
           '&.MuiInputBase-root': {
             backgroundColor: 'var(--white)',
             borderRadius: 'var(--radius-max)',

--- a/src/features/language_group_selector/useLanguageGroupSelector.tsx
+++ b/src/features/language_group_selector/useLanguageGroupSelector.tsx
@@ -12,6 +12,7 @@ import { schedulesBuildHistoryList } from '@services/app/schedules';
 import { assignmentsHistoryState } from '@states/schedules';
 import { languageGroupsState } from '@states/field_service_groups';
 import { refreshLocalesResources } from '@services/i18n';
+import { useTextWidth } from '@hooks/useTextWidth';
 
 const useGroupLanguageSelector = () => {
   const { t } = useAppTranslation();
@@ -96,7 +97,15 @@ const useGroupLanguageSelector = () => {
     validateDataView();
   }, [value, languageGroups]);
 
-  return { display, options, value, renderValue, handleChange };
+  const selectWidth = useTextWidth({
+    texts: [
+      t('tr_hostCongregation'),
+      ...options.map((option) => (option.value !== 'main' ? option.label : '')),
+    ],
+    padding: 82,
+  });
+
+  return { display, options, value, renderValue, handleChange, selectWidth };
 };
 
 export default useGroupLanguageSelector;

--- a/src/hooks/useTextWidth.tsx
+++ b/src/hooks/useTextWidth.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+
+const canvas =
+  typeof document !== 'undefined' ? document.createElement('canvas') : null;
+
+export const useTextWidth = ({
+  texts,
+  font = '16px Inter, sans-serif',
+  padding = 32,
+}: {
+  texts: string[];
+  font?: string;
+  padding?: number;
+}) => {
+  return useMemo(() => {
+    if (!texts.length || !canvas) return 0;
+
+    const context = canvas.getContext('2d');
+    if (!context) return 0;
+
+    context.font = font;
+
+    let maxWidth = 0;
+
+    for (let i = 0; i < texts.length; i++) {
+      const width = context.measureText(texts[i]).width;
+      if (width > maxWidth) maxWidth = width;
+    }
+
+    return Math.ceil(maxWidth + padding);
+  }, [texts, font, padding]);
+};


### PR DESCRIPTION
# Description

Added a reusable useTextWidth hook and applied it to dynamically adjust the width of congregation and group selector. This ensures proper display across different languages and text lengths.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
