### PR TITLE
feat(persons): introduce infirm parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4160,9 +4160,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@react-pdf/fns": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4114,9 +4114,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4142,9 +4142,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -17706,22 +17706,22 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20448,9 +20448,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
-      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/src/definition/person.ts
+++ b/src/definition/person.ts
@@ -77,6 +77,7 @@ export type PersonType = {
     timeAway: TimeAwayType[];
     archived: { value: boolean; updatedAt: string };
     disqualified: { value: boolean; updatedAt: string };
+    infirm_pioneer: { value: boolean; updatedAt: string };
     email: { value: string; updatedAt: string };
     address: { value: string; updatedAt: string };
     phone: { value: string; updatedAt: string };

--- a/src/features/ministry/hooks/useMinistryYearlyRecord.tsx
+++ b/src/features/ministry/hooks/useMinistryYearlyRecord.tsx
@@ -423,6 +423,7 @@ const useMinistryYearlyRecord = (year: string) => {
     bible_studies,
     hoursEnabled,
     isFR,
+    isFS,
     yearlyReports: yearlyUserReports,
     yearlyCongReports,
     hours_fulltime,

--- a/src/features/ministry/service_year/yearly_stats/pioneer_stats/index.tsx
+++ b/src/features/ministry/service_year/yearly_stats/pioneer_stats/index.tsx
@@ -1,10 +1,11 @@
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { PioneerStatsProps } from './index.types';
 import usePioneerStats from './usePioneerStats';
 import Divider from '@components/divider';
 import LabelRow from '../label_row';
 import Typography from '@components/typography';
+import { IconInfo } from '@components/icons';
 
 const PioneerStats = ({ year }: PioneerStatsProps) => {
   const { t } = useAppTranslation();
@@ -17,9 +18,19 @@ const PioneerStats = ({ year }: PioneerStatsProps) => {
       <Stack spacing="16px" padding="8px 0">
         <Typography className="h3">{t('tr_pioneerServiceStats')}</Typography>
 
-        <Typography className="body-regular" color="var(--grey-400)">
-          {t('tr_infirmPioneerNoGoal')}
-        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: '8px',
+          }}
+        >
+          <IconInfo color="var(--grey-350)" />
+          <Typography className="body-small-regular" color="var(--grey-350)">
+            {t('tr_infirmPioneerNoGoal')}
+          </Typography>
+        </Box>
       </Stack>
     );
   }

--- a/src/features/ministry/service_year/yearly_stats/pioneer_stats/index.tsx
+++ b/src/features/ministry/service_year/yearly_stats/pioneer_stats/index.tsx
@@ -9,8 +9,20 @@ import Typography from '@components/typography';
 const PioneerStats = ({ year }: PioneerStatsProps) => {
   const { t } = useAppTranslation();
 
-  const { goal, hours_left, isCurrentSY, hours_balance, monthly_goal } =
+  const { goal, hours_left, isCurrentSY, hours_balance, monthly_goal, isInfirm } =
     usePioneerStats(year);
+
+  if (isInfirm) {
+    return (
+      <Stack spacing="16px" padding="8px 0">
+        <Typography className="h3">{t('tr_pioneerServiceStats')}</Typography>
+
+        <Typography className="body-regular" color="var(--grey-400)">
+          {t('tr_infirmPioneerNoGoal')}
+        </Typography>
+      </Stack>
+    );
+  }
 
   return (
     <Stack spacing="16px" padding="8px 0">

--- a/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
+++ b/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
@@ -17,7 +17,7 @@ import usePerson from '@features/persons/hooks/usePerson';
 const usePioneerStats = (year: string) => {
   const { person } = useCurrentUser();
 
-  const { personIsEnrollmentActive } = usePerson();
+  const { personIsEnrollmentActive, personIsInfirmPioneer } = usePerson();
 
   const {
     start_month,
@@ -44,7 +44,13 @@ const usePioneerStats = (year: string) => {
     return year === currentSY;
   }, [year]);
 
+  const isInfirm = useMemo(() => {
+    return personIsInfirmPioneer(person);
+  }, [person]);
+
   const goal = useMemo(() => {
+    if (isInfirm) return 0;
+
     const enrollment = person!.person_data.enrollments.find((record) => {
       if (record._deleted) return false;
 
@@ -82,9 +88,11 @@ const usePioneerStats = (year: string) => {
     const monthDiff = computeMonthsDiff(startDate, endDate) + 1;
 
     return monthDiff * 50;
-  }, [person, start_month, end_month]);
+  }, [person, start_month, end_month, isInfirm]);
 
   const minutes_left = useMemo(() => {
+    if (isInfirm) return 0;
+
     if (hours_fulltime.total > goal) return 0;
 
     const sumHours = goal - hours_fulltime.total;
@@ -97,13 +105,15 @@ const usePioneerStats = (year: string) => {
     const currentMinutes = hoursCurrent * 60 + (minutesCurrent || 0);
 
     return Math.max(remainingMinutes - currentMinutes, 0);
-  }, [hours_fulltime, goal, hours_total, isCurrentSY]);
+  }, [hours_fulltime, goal, hours_total, isCurrentSY, isInfirm]);
 
   const hours_left = useMemo(() => {
     return convertMinutesToLongTime(minutes_left);
   }, [minutes_left]);
 
   const hours_balance = useMemo(() => {
+    if (isInfirm) return 0;
+
     let balance = 0;
 
     for (const report of yearlyCongReports) {
@@ -173,9 +183,11 @@ const usePioneerStats = (year: string) => {
     if (balance === 0) return 0;
 
     return balance > 0 ? `+${balance}` : balance.toString();
-  }, [yearlyReports, yearlyCongReports, personIsEnrollmentActive, person]);
+  }, [yearlyReports, yearlyCongReports, personIsEnrollmentActive, person, isInfirm]);
 
   const monthly_goal = useMemo(() => {
+    if (isInfirm) return '0';
+
     if (!isCurrentSY) return '0';
 
     const currentMonth = formatDate(new Date(), 'yyyy/MM');
@@ -198,7 +210,7 @@ const usePioneerStats = (year: string) => {
     const value = Math.round(minutes_left / months.length);
 
     return convertMinutesToLongTime(value);
-  }, [end_month, reports, minutes_left, isCurrentSY]);
+  }, [end_month, reports, minutes_left, isCurrentSY, isInfirm]);
 
   return {
     goal,
@@ -206,6 +218,7 @@ const usePioneerStats = (year: string) => {
     isCurrentSY,
     hours_balance,
     monthly_goal,
+    isInfirm,
   };
 };
 

--- a/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
+++ b/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
@@ -44,9 +44,7 @@ const usePioneerStats = (year: string) => {
     return year === currentSY;
   }, [year]);
 
-  const isInfirm = useMemo(() => {
-    return personIsInfirmPioneer(person);
-  }, [person]);
+  const isInfirm = personIsInfirmPioneer(person);
 
   const goal = useMemo(() => {
     if (isInfirm) return 0;

--- a/src/features/ministry/service_year/yearly_stats/year_item/index.tsx
+++ b/src/features/ministry/service_year/yearly_stats/year_item/index.tsx
@@ -7,7 +7,12 @@ import HoursStats from '../hours_stats';
 import PioneerStats from '../pioneer_stats';
 
 const YearlItem = ({ year }: YearlyItemProps) => {
-  const { hours, hoursEnabled, isFR } = useYearItem(year);
+  const { hours, hoursEnabled, isFR, isFS, isInfirm } = useYearItem(year);
+
+  // Show pioneer stats panel for:
+  // - All FR (regular) pioneers (always has a yearly goal)
+  // - FS (special) pioneers who are marked infirm (to show the "no goal" notice)
+  const showPioneerStats = isFR || (isFS && isInfirm);
 
   return (
     <Stack
@@ -22,9 +27,10 @@ const YearlItem = ({ year }: YearlyItemProps) => {
 
       <BibleStudiesStats year={year} />
 
-      {isFR && <PioneerStats year={year} />}
+      {showPioneerStats && <PioneerStats year={year} />}
     </Stack>
   );
 };
 
 export default YearlItem;
+

--- a/src/features/ministry/service_year/yearly_stats/year_item/useYearItem.tsx
+++ b/src/features/ministry/service_year/yearly_stats/year_item/useYearItem.tsx
@@ -1,9 +1,15 @@
 import useMinistryYearlyRecord from '@features/ministry/hooks/useMinistryYearlyRecord';
+import { useCurrentUser } from '@hooks/index';
+import { personIsInfirmPioneer } from '@services/app/persons';
 
 const useYearItem = (year: string) => {
-  const { hours, isFR, hoursEnabled } = useMinistryYearlyRecord(year);
+  const { person } = useCurrentUser();
 
-  return { hours, hoursEnabled, isFR };
+  const { hours, isFR, isFS, hoursEnabled } = useMinistryYearlyRecord(year);
+
+  const isInfirm = person ? personIsInfirmPioneer(person) : false;
+
+  return { hours, hoursEnabled, isFR, isFS, isInfirm };
 };
 
 export default useYearItem;

--- a/src/features/persons/enrollments/index.tsx
+++ b/src/features/persons/enrollments/index.tsx
@@ -1,9 +1,11 @@
 import { Box } from '@mui/material';
-import { IconAdd } from '@components/icons';
+import { IconAdd, IconHelpFilled } from '@components/icons';
 import { useAppTranslation, useCurrentUser } from '@hooks/index';
 import useEnrollments from './useEnrollments';
 import Button from '@components/button';
+import Checkbox from '@components/checkbox';
 import EnrollmentItem from './enrollment_item';
+import Tooltip from '@components/tooltip';
 import Typography from '@components/typography';
 
 const PersonEnrollments = () => {
@@ -18,6 +20,9 @@ const PersonEnrollments = () => {
     handleEndDateChange,
     handleStartDateChange,
     handleEnrollmentChange,
+    hasFREnrollment,
+    infirmPioneer,
+    handleInfirmPioneerChange,
   } = useEnrollments();
 
   return (
@@ -25,20 +30,65 @@ const PersonEnrollments = () => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        gap: '16px',
+        gap: '8px',
       }}
     >
-      <Typography className="h2">{t('tr_enrollments')}</Typography>
+      {/* Title row: always rendered to reserve height; hidden when not applicable */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '8px',
+        }}
+      >
+        <Typography className="h2">{t('tr_enrollments')}</Typography>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            opacity: hasFREnrollment ? 1 : 0,
+            visibility: hasFREnrollment ? 'visible' : 'hidden',
+            transition: 'opacity 0.15s ease, visibility 0.15s ease',
+          }}
+        >
+          <Checkbox
+            label={t('tr_infirmPioneer')}
+            checked={infirmPioneer}
+            onChange={(e) => handleInfirmPioneerChange(e.target.checked)}
+            readOnly={!isPersonEditor}
+            sx={{ margin: '4px' }}
+          />
+          <Tooltip
+            title={t('tr_infirmPioneerDesc')}
+            placement="bottom-end"
+            variant="icon"
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                color: 'var(--accent-350)',
+                transition: 'color 0.2s',
+                '&:hover': { color: 'var(--accent-main)' },
+                cursor: 'pointer',
+              }}
+            >
+              <IconHelpFilled width={16} height={16} color="currentColor" />
+            </Box>
+          </Tooltip>
+        </Box>
+      </Box>
 
       <Box
         sx={{
-          marginTop: '16px',
           display: 'flex',
           flexDirection: 'column',
           gap: '16px',
           maxHeight: '350px',
           overflow: 'auto',
-          paddingTop: activeHistory.length > 0 ? '4px' : 'unset',
+          paddingTop: activeHistory.length > 0 ? '8px' : 'unset',
         }}
       >
         {isPersonEditor && activeHistory.length === 0 && (

--- a/src/features/persons/enrollments/useEnrollments.tsx
+++ b/src/features/persons/enrollments/useEnrollments.tsx
@@ -5,6 +5,7 @@ import { personCurrentDetailsState } from '@states/persons';
 import { setPersonCurrentDetails } from '@services/states/persons';
 import { EnrollmentType } from '@definition/person';
 import { formatDate } from '@utils/date';
+import { personIsInfirmPioneer } from '@services/app/persons';
 
 const useEnrollments = () => {
   const { id } = useParams();
@@ -19,7 +20,18 @@ const useEnrollments = () => {
       .sort((a, b) => a.start_date.localeCompare(b.start_date));
   }, [person]);
 
-  const handleAddHistory = async () => {
+  const hasFREnrollment = useMemo(() => {
+    return person.person_data.enrollments.some(
+      (record) =>
+        record._deleted === false &&
+        (record.enrollment === 'FR' || record.enrollment === 'FS') &&
+        record.end_date === null
+    );
+  }, [person]);
+
+  const infirmPioneer = personIsInfirmPioneer(person);
+
+  const handleAddHistory = () => {
     const newPerson = structuredClone(person);
 
     newPerson.person_data.enrollments.push({
@@ -34,7 +46,7 @@ const useEnrollments = () => {
     setPersonCurrentDetails(newPerson);
   };
 
-  const handleDeleteHistory = async (id: string) => {
+  const handleDeleteHistory = (id: string) => {
     const newPerson = structuredClone(person);
 
     if (!isAddPerson) {
@@ -54,7 +66,7 @@ const useEnrollments = () => {
     setPersonCurrentDetails(newPerson);
   };
 
-  const handleStartDateChange = async (id: string, value: Date) => {
+  const handleStartDateChange = (id: string, value: Date) => {
     if (value === null) return;
 
     const newPerson = structuredClone(person);
@@ -69,7 +81,7 @@ const useEnrollments = () => {
     setPersonCurrentDetails(newPerson);
   };
 
-  const handleEndDateChange = async (id: string, value: Date | null) => {
+  const handleEndDateChange = (id: string, value: Date | null) => {
     const newPerson = structuredClone(person);
 
     const current = newPerson.person_data.enrollments.find(
@@ -82,7 +94,7 @@ const useEnrollments = () => {
     setPersonCurrentDetails(newPerson);
   };
 
-  const handleEnrollmentChange = async (id: string, value: string) => {
+  const handleEnrollmentChange = (id: string, value: string) => {
     const newPerson = structuredClone(person);
 
     const newValue = value as EnrollmentType;
@@ -91,8 +103,21 @@ const useEnrollments = () => {
       (history) => history.id === id
     );
 
+    if (!current) return;
+
     current.enrollment = newValue;
     current.updatedAt = new Date().toISOString();
+
+    setPersonCurrentDetails(newPerson);
+  };
+
+  const handleInfirmPioneerChange = (value: boolean) => {
+    const newPerson = structuredClone(person);
+
+    newPerson.person_data.infirm_pioneer = {
+      value,
+      updatedAt: new Date().toISOString(),
+    };
 
     setPersonCurrentDetails(newPerson);
   };
@@ -104,6 +129,9 @@ const useEnrollments = () => {
     handleStartDateChange,
     handleEndDateChange,
     handleEnrollmentChange,
+    hasFREnrollment,
+    infirmPioneer,
+    handleInfirmPioneerChange,
   };
 };
 

--- a/src/features/persons/filter/useFilter.tsx
+++ b/src/features/persons/filter/useFilter.tsx
@@ -147,6 +147,7 @@ const useFilter = () => {
           { id: 'FR', name: t('tr_FR') },
           { id: 'FS', name: t('tr_FS') },
           { id: 'FMF', name: t('tr_FMF') },
+          { id: 'IP', name: t('tr_infirmPioneer') },
         ],
       },
       {

--- a/src/features/persons/hooks/usePerson.tsx
+++ b/src/features/persons/hooks/usePerson.tsx
@@ -5,6 +5,7 @@ import { BadgeColor } from '@definition/app';
 import { fullnameOptionState } from '@states/settings';
 import { buildPersonFullname } from '@utils/common';
 import { formatDate } from '@utils/date';
+import { personIsInfirmPioneer as _personIsInfirmPioneer } from '@services/app/persons';
 
 const usePerson = () => {
   const { t } = useAppTranslation();
@@ -184,6 +185,10 @@ const usePerson = () => {
     return formatDate(firstDate, 'yyyy/MM');
   };
 
+  const personIsInfirmPioneer = (person: PersonType) => {
+    return _personIsInfirmPioneer(person);
+  };
+
   const getBadges = (person: PersonType, month?: string) => {
     const badges: { name: string; color: BadgeColor }[] = [];
 
@@ -231,6 +236,10 @@ const usePerson = () => {
 
       if (isFS) {
         badges.push({ name: t('tr_FS'), color: 'orange' });
+      }
+
+      if ((isFR || isFS) && _personIsInfirmPioneer(person)) {
+        badges.push({ name: t('tr_infirmPioneer'), color: 'grey' });
       }
     }
 
@@ -404,6 +413,7 @@ const usePerson = () => {
     personIsAPContinuousYearActive,
     personIsElder,
     personIsMS,
+    personIsInfirmPioneer,
   };
 };
 

--- a/src/features/persons/privileges/index.tsx
+++ b/src/features/persons/privileges/index.tsx
@@ -34,13 +34,12 @@ const PersonPrivileges = () => {
 
       <Box
         sx={{
-          marginTop: '16px',
           display: 'flex',
           flexDirection: 'column',
           gap: '16px',
           maxHeight: '350px',
           overflow: 'auto',
-          paddingTop: activeHistory.length > 0 ? '4px' : 'unset',
+          paddingTop: activeHistory.length > 0 ? '12px' : 'unset',
         }}
       >
         {isPersonEditor && activeHistory.length === 0 && (

--- a/src/features/persons/spiritual_status/history/index.tsx
+++ b/src/features/persons/spiritual_status/history/index.tsx
@@ -6,6 +6,15 @@ import Button from '@components/button';
 import Checkbox from '@components/checkbox';
 import Tooltip from '@components/tooltip';
 
+const tooltipIconSx = {
+  display: 'flex',
+  alignItems: 'center',
+  color: 'var(--accent-350)',
+  transition: 'color 0.2s',
+  '&:hover': { color: 'var(--accent-main)' },
+  cursor: 'pointer',
+};
+
 const StatusHistory = ({
   active,
   expanded,
@@ -42,7 +51,9 @@ const StatusHistory = ({
             placement="bottom-start"
             variant="icon"
           >
-            <IconHelpFilled width={16} height={16} />
+            <Box sx={tooltipIconSx}>
+              <IconHelpFilled width={16} height={16} color="currentColor" />
+            </Box>
           </Tooltip>
         </Box>
         <IconButton sx={{ padding: 0 }} onClick={onExpand}>

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -526,5 +526,5 @@
   "tr_personalDetails": "Personal details",
   "tr_infirmPioneer": "Infirm pioneer",
   "tr_infirmPioneerDesc": "This pioneer is exempt from the yearly hour requirement and serves as much as able.",
-  "tr_infirmPioneerNoGoal": "This pioneer serves without a yearly hour goal as an infirm pioneer."
+  "tr_infirmPioneerNoGoal": "As an infirm pioneer, you can serve as much as you are able without a yearly hour goal."
 }

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -523,5 +523,8 @@
   "tr_maximumAmountOfGroupsIs10": "Maximum amount of field service groups is 10",
   "tr_personAwayNotice": "This person is away: {{ date }}",
   "tr_weekendTemplateShowSongs": "Display songs on weekend meeting schedules",
-  "tr_personalDetails": "Personal details"
+  "tr_personalDetails": "Personal details",
+  "tr_infirmPioneer": "Infirm pioneer",
+  "tr_infirmPioneerDesc": "This pioneer is exempt from the yearly hour requirement and serves as much as able.",
+  "tr_infirmPioneerNoGoal": "This pioneer serves without a yearly hour goal as an infirm pioneer."
 }

--- a/src/pages/dashboard/ministry/useMinistry.tsx
+++ b/src/pages/dashboard/ministry/useMinistry.tsx
@@ -5,6 +5,7 @@ import {
   personIsFMF,
   personIsFR,
   personIsFS,
+  personIsInfirmPioneer,
 } from '@services/app/persons';
 import { currentMonthServiceYear, currentServiceYear } from '@utils/date';
 import useMinistryMonthlyRecord from '@features/ministry/hooks/useMinistryMonthlyRecord';
@@ -29,6 +30,8 @@ const useMinistry = () => {
     publisher: true,
   });
 
+  const isInfirm = person ? personIsInfirmPioneer(person) : false;
+
   const isPioneer = useMemo(() => {
     if (!person) return false;
 
@@ -48,10 +51,12 @@ const useMinistry = () => {
     return hours_total;
   }, [hours_total]);
 
+  const displayedBalance = isInfirm ? '' : String(hours_balance);
+
   return {
     isPioneer,
     hours,
-    hours_balance: String(hours_balance),
+    hours_balance: displayedBalance,
     enable_AP_application,
   };
 };

--- a/src/services/app/persons.ts
+++ b/src/services/app/persons.ts
@@ -401,6 +401,10 @@ export const personIsFS = (person: PersonType) => {
   return hasActive ? true : false;
 };
 
+export const personIsInfirmPioneer = (person: PersonType) => {
+  return person.person_data.infirm_pioneer?.value === true;
+};
+
 export const personHasNoAssignment = (person: PersonType) => {
   const dataView = store.get(userDataViewState);
 
@@ -524,6 +528,7 @@ export const applyGroupFilters = (
       const isMSFilter = groups.includes('ministerialServant');
       const isMidweekStudentFilter = groups.includes('midweekStudent');
       const isNoAssignmentFilter = groups.includes('noAssignment');
+      const isInfirmPioneerFilter = groups.includes('IP');
 
       const male = person.person_data.male.value;
       const female = person.person_data.female.value;
@@ -542,6 +547,7 @@ export const applyGroupFilters = (
         person.person_data.midweek_meeting_student.active.value;
       const hasNoAssignment = personHasNoAssignment(person);
       const isFamilyHead = person.person_data.family_members?.head;
+      const isInfirmPioneer = personIsInfirmPioneer(person);
 
       // if you want to add another condition here, add it after the male and
       // female check to avoid it to be overwritten
@@ -604,6 +610,9 @@ export const applyGroupFilters = (
 
       // family head selected
       if (isPassed && isFamilyHeadFilter) isPassed = isFamilyHead;
+
+      // infirm pioneer selected
+      if (isPassed && isInfirmPioneerFilter) isPassed = isInfirmPioneer;
 
       if (isPassed) {
         finalResult.push(person);

--- a/src/services/dexie/schema.ts
+++ b/src/services/dexie/schema.ts
@@ -203,6 +203,7 @@ export const personSchema: PersonType = {
     timeAway: [],
     archived: { value: false, updatedAt: '' },
     disqualified: { value: false, updatedAt: '' },
+    infirm_pioneer: { value: false, updatedAt: '' },
     email: { value: '', updatedAt: '' },
     address: { value: '', updatedAt: '' },
     phone: { value: '', updatedAt: '' },


### PR DESCRIPTION
# Description

This PR introduces the "Infirm Pioneer" feature, allowing aging or long-serving Regular (FR) and Special (FS) pioneers to be exempt from yearly hour-tracking requirements. 

Key changes include:
- Integrating a checkbox-based UI in the Enrollments section for qualifying pioneers (reserved in the layout to prevent UI shifts).
- Displaying an informative ❓ tooltip with conditional visibility.
- Implementing logic in `usePioneerStats` to suppress service-year "hours balance" badges and goals for infirm pioneers.
- Adding the `infirm_pioneer` flag to `PersonType` and a corresponding 'IP' group filter.
- Code has been audited against React best practices and optimized for performance.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
